### PR TITLE
Ensure original entrypoint runs

### DIFF
--- a/docker-entrypoint-wrapper.sh
+++ b/docker-entrypoint-wrapper.sh
@@ -43,4 +43,4 @@ if [ "$DEMO_SITE" = "1" ] ; then
 fi
 
 # Entrypoint
-"$@"
+exec docker-entrypoint.sh "$@"


### PR DESCRIPTION
Denna bör ju alltid köras, borde inte fungerat utan den innan.